### PR TITLE
Docker builder

### DIFF
--- a/deception-core/src/main/java/com/deceptionkit/dockerfile/options/CopyCommandOptions.java
+++ b/deception-core/src/main/java/com/deceptionkit/dockerfile/options/CopyCommandOptions.java
@@ -7,6 +7,7 @@ public class CopyCommandOptions extends CommandOptions {
     protected static final String LINK = "--link";
     protected static final String PARENTS = "--parents";
     protected static final String EXCLUDE = "--exclude";
+    protected static final String FROM = "--from";
 
     public CopyCommandOptions chown(String user, String group) {
         this.options.add(CopyCommandOptions.CHOWN + "=" + user + ":" + group);
@@ -45,6 +46,11 @@ public class CopyCommandOptions extends CommandOptions {
 
     public CopyCommandOptions exclude(String pattern) {
         this.options.add(CopyCommandOptions.EXCLUDE + "=" + pattern);
+        return this;
+    }
+
+    public CopyCommandOptions from(String stage) {
+        this.options.add(CopyCommandOptions.FROM + "=" + stage);
         return this;
     }
 }


### PR DESCRIPTION
Create DockerfileBuilder, added support for all Dockerfile commands and options as well as options that apply only to specific options enforcing the use of the correct optional arguments.

This component does not check semantics of the generated instructions.