### PR TITLE
1 apiversion on method overrides controller

### DIFF
--- a/deception-core/src/main/java/com/deceptionkit/TempYaml.java
+++ b/deception-core/src/main/java/com/deceptionkit/TempYaml.java
@@ -9,17 +9,22 @@ import java.util.Map;
 
 public class TempYaml {
 
+    private String temp;
+    private String temp2;
 
+    public String getTemp() {
+        return temp;
+    }
 
-    public static void main(String[] args) throws JsonProcessingException {
-        String temp = "{\"group1\":[{\"name\":\"role2\",\"description\":\"Role for role2\",\"composite\":false,\"clientRole\":false,\"realmName\":\"master\",\"clientName\":null}],\"group2\":[{\"name\":\"role2\",\"description\":\"Role for role2\",\"composite\":false,\"clientRole\":false,\"realmName\":\"master\",\"clientName\":null}],\"Sales\":[{\"name\":\"role2\",\"description\":\"Role for role2\",\"composite\":false,\"clientRole\":false,\"realmName\":\"master\",\"clientName\":null}],\"Marketing\":[{\"name\":\"role3\",\"description\":\"Role for role3\",\"composite\":false,\"clientRole\":true,\"realmName\":null,\"clientName\":\"client1\"}],\"Research and Development\":[{\"name\":\"role3\",\"description\":\"Role for role3\",\"composite\":false,\"clientRole\":true,\"realmName\":null,\"clientName\":\"client1\"}]}\n";
+    public void setTemp(String temp) {
+        this.temp = temp;
+    }
 
-        //how to convert temp json string to Role class
-        Map<String, List<Role>> map = new ObjectMapper().readValue(temp, Map.class);
+    public String getTemp2() {
+        return temp2;
+    }
 
-        System.out.println(map.get("group1").get(0).getName());
-        //System.out.println(role.getName());
-
-
+    public void setTemp2(String temp2) {
+        this.temp2 = temp2;
     }
 }

--- a/deception-core/src/main/java/com/deceptionkit/generation/GenerationController.java
+++ b/deception-core/src/main/java/com/deceptionkit/generation/GenerationController.java
@@ -1,5 +1,6 @@
 package com.deceptionkit.generation;
 
+import com.deceptionkit.TempYaml;
 import com.deceptionkit.dockerfile.DockerfileBuilder;
 import com.deceptionkit.dockerfile.commands.CommandBuilder;
 import com.deceptionkit.dockerfile.options.CommandOptionsBuilder;
@@ -39,9 +40,32 @@ public class GenerationController {
 
     private final Logger logger;
 
-
     public GenerationController() {
         this.logger = org.slf4j.LoggerFactory.getLogger(GenerationController.class);
+    }
+
+    @GetMapping(value = "/idprovider/jsontest", produces = "application/json")
+    @ResponseBody
+    public TempYaml getJsonTest() {
+        TempYaml tempYaml = new TempYaml();
+        tempYaml.setTemp2("json");
+        return tempYaml;
+    }
+
+    @GetMapping(value = "/idprovider/yamltest", produces = "application/yaml")
+    @ResponseBody
+    public TempYaml getYamlTeest() {
+        TempYaml tempYaml = new TempYaml();
+        tempYaml.setTemp("yaml");
+        return tempYaml;
+    }
+
+    @PostMapping(value = "/idprovider/consyamltest", consumes = {"application/yaml", "text/yaml"}, produces = {"application/yaml", "text/yaml"})
+    @ResponseBody
+    public TempYaml getProdYamlTest(@RequestBody TempYaml tempYaml) {
+        TempYaml temp = new TempYaml();
+        temp.setTemp("cons yaml");
+        return temp;
     }
 
     @PostMapping(value = "/idprovider/resources", consumes = {"application/yaml", "application/yml", "text/yaml", "text/yml"}, produces = "application/json")
@@ -54,22 +78,22 @@ public class GenerationController {
         Integer groupsPerUser = idProviderDefinition.getSpecification().getUsers().getGroups_per_user();
         String domain = idProviderDefinition.getSpecification().getDomain();
 
-        List<RoleDefinition> roleDefintions = idProviderDefinition.getSpecification().getRoles().getDefinitions();
+        List<RoleDefinition> roleDefinitions = idProviderDefinition.getSpecification().getRoles().getDefinitions();
         List<ClientDefinition> clientDefinitions = idProviderDefinition.getSpecification().getClients().getDefinitions();
         List<GroupDefinition> groupDefinitions = idProviderDefinition.getSpecification().getGroups().getDefinitions();
         List<UserDefinition> userDefinitions = idProviderDefinition.getSpecification().getUsers().getDefinitions();
 
         //consistency checks
-        if (!clientRolesExist(clientDefinitions, roleDefintions)) {
+        if (!clientRolesExist(clientDefinitions, roleDefinitions)) {
             throw new RuntimeException("Client roles do not exist in role definitions");
         }
         if (!userGroupsExist(userDefinitions, groupDefinitions)) {
             throw new RuntimeException("User groups do not exist in group definitions");
         }
-        if (!groupRolesExist(groupDefinitions, roleDefintions)) {
+        if (!groupRolesExist(groupDefinitions, roleDefinitions)) {
             throw new RuntimeException("Group roles do not exist in role definitions");
         }
-        if (!clientRolesAreClientScoped(clientDefinitions, roleDefintions)) {
+        if (!clientRolesAreClientScoped(clientDefinitions, roleDefinitions)) {
             throw new RuntimeException("Client roles are not client scoped");
         }
         if (groupsPerUser > totalGroups) {

--- a/deception-core/src/main/java/com/deceptionkit/generation/GenerationController.java
+++ b/deception-core/src/main/java/com/deceptionkit/generation/GenerationController.java
@@ -1,10 +1,8 @@
 package com.deceptionkit.generation;
 
-import com.deceptionkit.TempYaml;
 import com.deceptionkit.dockerfile.DockerfileBuilder;
 import com.deceptionkit.dockerfile.commands.CommandBuilder;
 import com.deceptionkit.dockerfile.options.CommandOptionsBuilder;
-import com.deceptionkit.dockerfile.options.CopyCommandOptions;
 import com.deceptionkit.generation.model.MockResources;
 import com.deceptionkit.generation.utils.MockMergeHelper;
 import com.deceptionkit.mockaroo.MockFactory;
@@ -35,37 +33,13 @@ import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/generation")
-@ApiVersion({"1", "1.1"})
+@ApiVersion(value = {"1", "1.1"})
 public class GenerationController {
 
     private final Logger logger;
 
     public GenerationController() {
         this.logger = org.slf4j.LoggerFactory.getLogger(GenerationController.class);
-    }
-
-    @GetMapping(value = "/idprovider/jsontest", produces = "application/json")
-    @ResponseBody
-    public TempYaml getJsonTest() {
-        TempYaml tempYaml = new TempYaml();
-        tempYaml.setTemp2("json");
-        return tempYaml;
-    }
-
-    @GetMapping(value = "/idprovider/yamltest", produces = "application/yaml")
-    @ResponseBody
-    public TempYaml getYamlTeest() {
-        TempYaml tempYaml = new TempYaml();
-        tempYaml.setTemp("yaml");
-        return tempYaml;
-    }
-
-    @PostMapping(value = "/idprovider/consyamltest", consumes = {"application/yaml", "text/yaml"}, produces = {"application/yaml", "text/yaml"})
-    @ResponseBody
-    public TempYaml getProdYamlTest(@RequestBody TempYaml tempYaml) {
-        TempYaml temp = new TempYaml();
-        temp.setTemp("cons yaml");
-        return temp;
     }
 
     @PostMapping(value = "/idprovider/resources", consumes = {"application/yaml", "application/yml", "text/yaml", "text/yml"}, produces = "application/json")

--- a/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersion.java
+++ b/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersion.java
@@ -9,4 +9,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiVersion {
     String[] value();
+
+    boolean override() default false;
 }

--- a/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersionRequestMappingHandlerMapping.java
+++ b/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersionRequestMappingHandlerMapping.java
@@ -1,5 +1,7 @@
 package com.deceptionkit.spring.apiversion;
 
+import com.deceptionkit.generation.GenerationController;
+import org.slf4j.Logger;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.servlet.mvc.condition.RequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
@@ -9,6 +11,8 @@ import org.springframework.web.util.pattern.PathPatternParser;
 import java.lang.reflect.Method;
 
 public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
+
+    private final Logger logger = org.slf4j.LoggerFactory.getLogger(ApiVersionRequestMappingHandlerMapping.class);
 
     private final String prefix;
 
@@ -21,9 +25,27 @@ public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandle
         RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
         if (info == null) return null;
 
+//        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+//        ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
+//
+//        RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
+//        RequestCondition<?> typeCondition = super.getCustomTypeCondition(handlerType);
+//
+//        RequestMappingInfo newInfo = null;
+//
+//        if (methodAnnotation != null) {
+//            logger.debug("methodAnnotation not null, follows methodCondition");
+//            newInfo = createApiVersionInfo(null, methodAnnotation, methodCondition).combine(info);
+//        } else {
+//            if (typeAnnotation != null) {
+//                newInfo = createApiVersionInfo(typeAnnotation, null, typeCondition).combine(info);
+//            }
+//        }
+
         ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
         RequestMappingInfo newInfo = null;
         if (methodAnnotation != null) {
+            logger.debug("methodAnnotation not null, follows methodCondition");
             RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
             newInfo = createApiVersionInfo(methodAnnotation, methodCondition).combine(info);
         } else {
@@ -37,6 +59,25 @@ public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandle
         return newInfo;
     }
 
+//    private RequestMappingInfo createApiVersionInfo(ApiVersion typeAnnotation, ApiVersion methodAnnotation, RequestCondition<?> customCondition) {
+//        String[] values = typeAnnotation.value();
+//        String[] patterns = new String[values.length];
+//        for (int i = 0; i < values.length; i++) {
+//            patterns[i] = prefix + values[i];
+//        }
+//
+//        logger.debug("customCondition: " + customCondition.toString());
+//
+//
+//        RequestMappingInfo.Builder builder = RequestMappingInfo.paths(patterns);
+//        RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
+//        config.setPatternParser(new PathPatternParser());
+//        builder.options(config);
+//
+//        return builder.customCondition(customCondition).build();
+//
+//    }
+
     private RequestMappingInfo createApiVersionInfo(ApiVersion annotation, RequestCondition<?> customCondition) {
         String[] values = annotation.value();
         String[] patterns = new String[values.length];
@@ -44,6 +85,7 @@ public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandle
             patterns[i] = prefix + values[i];
         }
 
+        logger.debug("customCondition: " + customCondition);
 
         RequestMappingInfo.Builder builder = RequestMappingInfo.paths(patterns);
         RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();

--- a/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersionRequestMappingHandlerMapping.java
+++ b/deception-core/src/main/java/com/deceptionkit/spring/apiversion/ApiVersionRequestMappingHandlerMapping.java
@@ -1,14 +1,15 @@
 package com.deceptionkit.spring.apiversion;
 
-import com.deceptionkit.generation.GenerationController;
 import org.slf4j.Logger;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.web.servlet.mvc.condition.RequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.util.pattern.PathPatternParser;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandlerMapping {
 
@@ -25,49 +26,74 @@ public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandle
         RequestMappingInfo info = super.getMappingForMethod(method, handlerType);
         if (info == null) return null;
 
-//        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
-//        ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
-//
-//        RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
-//        RequestCondition<?> typeCondition = super.getCustomTypeCondition(handlerType);
-//
-//        RequestMappingInfo newInfo = null;
-//
-//        if (methodAnnotation != null) {
-//            logger.debug("methodAnnotation not null, follows methodCondition");
-//            newInfo = createApiVersionInfo(null, methodAnnotation, methodCondition).combine(info);
-//        } else {
-//            if (typeAnnotation != null) {
-//                newInfo = createApiVersionInfo(typeAnnotation, null, typeCondition).combine(info);
-//            }
+        ApiVersion methodApiVersion = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+        ApiVersion typeApiVersion = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
+
+//        if (typeApiVersion != null && typeApiVersion.override()) {
+//            logger.debug("Type ApiVersion annotation is trying to override");
+//            return info;
 //        }
 
-        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+//        RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
+//        RequestCondition<?> typeCondition = super.getCustomTypeCondition(handlerType);
+
         RequestMappingInfo newInfo = null;
-        if (methodAnnotation != null) {
-            logger.debug("methodAnnotation not null, follows methodCondition");
-            RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
-            newInfo = createApiVersionInfo(methodAnnotation, methodCondition).combine(info);
-        } else {
-            ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
-            if (typeAnnotation != null) {
-                RequestCondition<?> typeCondition = super.getCustomTypeCondition(handlerType);
-                newInfo = createApiVersionInfo(typeAnnotation, typeCondition).combine(info);
-            }
-        }
+        newInfo = createApiVersionInfo(methodApiVersion, typeApiVersion).combine(info);
+
+//        ApiVersion methodAnnotation = AnnotationUtils.findAnnotation(method, ApiVersion.class);
+//        RequestMappingInfo newInfo = null;
+//        if (methodAnnotation != null) {
+//            RequestCondition<?> methodCondition = super.getCustomMethodCondition(method);
+//            newInfo = createApiVersionInfo(methodAnnotation, methodCondition).combine(info);
+//        } else {
+//            ApiVersion typeAnnotation = AnnotationUtils.findAnnotation(handlerType, ApiVersion.class);
+//            if (typeAnnotation != null) {
+//                RequestCondition<?> typeCondition = super.getCustomTypeCondition(handlerType);
+//                newInfo = createApiVersionInfo(typeAnnotation, typeCondition).combine(info);
+//            }
+//        }
 
         return newInfo;
     }
 
-//    private RequestMappingInfo createApiVersionInfo(ApiVersion typeAnnotation, ApiVersion methodAnnotation, RequestCondition<?> customCondition) {
-//        String[] values = typeAnnotation.value();
+    private RequestMappingInfo createApiVersionInfo(ApiVersion methodApiVersion, ApiVersion typeApiVersion) {
+        List<String> valuesList = new ArrayList<>();
+        boolean typeOverrides = typeApiVersion != null && typeApiVersion.override();
+        boolean methodOverrides = methodApiVersion != null && methodApiVersion.override();
+        if (methodApiVersion != null) {
+            if (!typeOverrides) {
+                valuesList.addAll(List.of(methodApiVersion.value()));
+            }
+        }
+        if (typeApiVersion != null) {
+            if (!methodOverrides) {
+                valuesList.addAll(List.of(typeApiVersion.value()));
+            }
+        }
+        if (methodOverrides && typeOverrides) {
+            logger.warn("Both method and type ApiVersion annotations are trying to override, keeping all values.");
+            valuesList.addAll(List.of(methodApiVersion.value()));
+            valuesList.addAll(List.of(typeApiVersion.value()));
+        }
+
+        //prepend prefix to all values and convert to array
+        String[] patterns = valuesList.stream().map(value -> prefix + value).toArray(String[]::new);
+
+        RequestMappingInfo.Builder builder = RequestMappingInfo.paths(patterns);
+        RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
+        config.setPatternParser(new PathPatternParser());
+        builder.options(config);
+
+        return builder.build();
+
+    }
+
+//    private RequestMappingInfo createApiVersionInfo(ApiVersion annotation, RequestCondition<?> customCondition) {
+//        String[] values = annotation.value();
 //        String[] patterns = new String[values.length];
 //        for (int i = 0; i < values.length; i++) {
 //            patterns[i] = prefix + values[i];
 //        }
-//
-//        logger.debug("customCondition: " + customCondition.toString());
-//
 //
 //        RequestMappingInfo.Builder builder = RequestMappingInfo.paths(patterns);
 //        RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
@@ -77,22 +103,4 @@ public class ApiVersionRequestMappingHandlerMapping extends RequestMappingHandle
 //        return builder.customCondition(customCondition).build();
 //
 //    }
-
-    private RequestMappingInfo createApiVersionInfo(ApiVersion annotation, RequestCondition<?> customCondition) {
-        String[] values = annotation.value();
-        String[] patterns = new String[values.length];
-        for (int i = 0; i < values.length; i++) {
-            patterns[i] = prefix + values[i];
-        }
-
-        logger.debug("customCondition: " + customCondition);
-
-        RequestMappingInfo.Builder builder = RequestMappingInfo.paths(patterns);
-        RequestMappingInfo.BuilderConfiguration config = new RequestMappingInfo.BuilderConfiguration();
-        config.setPatternParser(new PathPatternParser());
-        builder.options(config);
-
-        return builder.customCondition(customCondition).build();
-
-    }
 }


### PR DESCRIPTION
Added new parameter `override` to ApiVersion annotation, this parameters indicates if the annotated type or method should override the version values specified in an annotated method or type.
This is the current behaviour:
- if annotated type overrides, method annotation values are ignored
- if annotated method overrides, type annotation values are ignored for that method
- if both annotated type and method override, all values are kept as valid for that method

A parameter will be added to the request mapping class to configure the behaviour of the override parameter.